### PR TITLE
Setup jetty module and use default for jarBranch when not specified

### DIFF
--- a/cloudhost-jetty/pom.xml
+++ b/cloudhost-jetty/pom.xml
@@ -10,7 +10,7 @@
   <url>http://maven.apache.org</url>
   <properties>
     <tomcat.version>8.0.28</tomcat.version>
-    <jarBranch>demo</jarBranch>
+    <jarBranch>default</jarBranch>
     <copyName>mrt-cloudhost-1.0.jar</copyName>
   </properties>
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -34,11 +34,10 @@
             </modules>
         </profile>
         <profile>
-          <id>emb</id> 
+            <id>jetty</id> 
             <modules>
-                <module>cloudhost-conf</module>
                 <module>cloudhost-src</module>
-                <module>cloudhost-emb</module>
+                <module>cloudhost-jetty</module>
             </modules>
         </profile>
      </profiles>


### PR DESCRIPTION
pom.xml to allow jetty only builds